### PR TITLE
Cast `isdigit()` & `isxdigit()` args to int

### DIFF
--- a/src/lint_iso3166.c
+++ b/src/lint_iso3166.c
@@ -132,7 +132,7 @@ GS1_SYNTAX_DICTIONARY_API gs1_lint_err_t gs1_lint_iso3166(const char* const data
 /// \cond
 #define GS1_LINTER_ISO3166_LOOKUP(cc, cc_len, valid) do {				\
 	valid = 0;									\
-	if (cc_len == 3 && isdigit(cc[0]) && isdigit(cc[1]) && isdigit(cc[2])) {	\
+	if (cc_len == 3 && isdigit((int)cc[0]) && isdigit((int)cc[1]) && isdigit((int)cc[2])) {	\
 		int v = (cc[0] - '0') * 100 + (cc[1] - '0') * 10 + cc[2] - '0';		\
 		GS1_LINTER_BITFIELD_LOOKUP(v, iso3166, valid);				\
 	}										\

--- a/src/lint_iso4217.c
+++ b/src/lint_iso4217.c
@@ -133,7 +133,7 @@ GS1_SYNTAX_DICTIONARY_API gs1_lint_err_t gs1_lint_iso4217(const char* const data
 /// \cond
 #define GS1_LINTER_ISO4217_LOOKUP(cc, cc_len, valid) do {				\
 	valid = 0;									\
-	if (cc_len == 3 && isdigit(cc[0]) && isdigit(cc[1]) && isdigit(cc[2])) {	\
+	if (cc_len == 3 && isdigit((int)cc[0]) && isdigit((int)cc[1]) && isdigit((int)cc[2])) {	\
 		int v = (cc[0] - '0') * 100 + (cc[1] - '0') * 10 + cc[2] - '0';		\
 		GS1_LINTER_BITFIELD_LOOKUP(v, iso4217, valid);				\
 	}										\

--- a/src/lint_mediatype.c
+++ b/src/lint_mediatype.c
@@ -124,7 +124,7 @@ GS1_SYNTAX_DICTIONARY_API gs1_lint_err_t gs1_lint_mediatype(const char* const da
 /// \cond
 #define GS1_LINTER_MEDIA_TYPE_LOOKUP(cc, cc_len, valid) do {			\
 	valid = 0;								\
-	if (cc_len == 2 && isdigit(cc[0]) && isdigit(cc[1])) {		\
+	if (cc_len == 2 && isdigit((int)cc[0]) && isdigit((int)cc[1])) {		\
 		int v = (cc[0] - '0') * 10 + (cc[1] - '0');			\
 		GS1_LINTER_BITFIELD_LOOKUP(v, mediatypes, valid);		\
 	}									\

--- a/src/lint_pcenc.c
+++ b/src/lint_pcenc.c
@@ -74,7 +74,7 @@ GS1_SYNTAX_DICTIONARY_API gs1_lint_err_t gs1_lint_pcenc(const char* const data, 
 				);
 			}
 
-			if (GS1_LINTER_UNLIKELY(!isxdigit(data[pos + 1]) || !isxdigit(data[pos + 2])))
+			if (GS1_LINTER_UNLIKELY(!isxdigit((int)data[pos + 1]) || !isxdigit((int)data[pos + 2])))
 				GS1_LINTER_RETURN_ERROR(
 					GS1_LINTER_INVALID_PERCENT_SEQUENCE,
 					pos,


### PR DESCRIPTION
Suppresses pedantic char-subscript warning (NetBSD)